### PR TITLE
fix .gitignore comment not starting at the beginning of the line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,7 +106,8 @@ ClientBin
 stylecop.*
 ~$*
 *.dbmdl
-Generated_Code #added for RIA/Silverlight projects
+#added for RIA/Silverlight projects
+Generated_Code
 
 # Backup & report files from converting an old project file to a newer
 # Visual Studio version. Backup files are not needed, because we have git ;-)


### PR DESCRIPTION
Hi,

A comment in .gitignore breaks satis/composer support. The Composer exclude filter does not supports comments which don't start at the beginning of the line.

https://github.com/composer/satis/issues/221#issuecomment-104714890#issuecomment-104714890