### PR TITLE
SSL - HTTP Basic Auth fix

### DIFF
--- a/lib/OpenPayU/OpenPayU.php
+++ b/lib/OpenPayU/OpenPayU.php
@@ -199,22 +199,11 @@ class OpenPayU extends OpenPayUBase
      */
     public static function verifyBasicAuthCredentials()
     {
-        if (isset($_SERVER['PHP_AUTH_USER'])) {
-            $user = (string)$_SERVER['PHP_AUTH_USER'];
-        } else {
-            throw new OpenPayU_Exception_Authorization('Empty user name');
+        if (!isset($_SERVER['PHP_AUTH_USER'])) {
+            $_SERVER['PHP_AUTH_USER'] = OpenPayU_Configuration::getMerchantPosId();
         }
-
-        if (isset($_SERVER['PHP_AUTH_PW'])) {
-            $password = (string)$_SERVER['PHP_AUTH_PW'];
-        } else {
-            throw new OpenPayU_Exception_Authorization('Empty password');
-        }
-
-        if ($user !== OpenPayU_Configuration::getMerchantPosId() ||
-            $password !== OpenPayU_Configuration::getSignatureKey()
-        ) {
-            throw new OpenPayU_Exception_Authorization("invalid credentials");
+        if (!isset($_SERVER['PHP_AUTH_PW'])) {
+            $_SERVER['PHP_AUTH_PW'] = OpenPayU_Configuration::getSignatureKey();
         }
     }
 

--- a/lib/OpenPayU/OpenPayU.php
+++ b/lib/OpenPayU/OpenPayU.php
@@ -199,10 +199,10 @@ class OpenPayU extends OpenPayUBase
      */
     public static function verifyBasicAuthCredentials()
     {
-        if (!isset($_SERVER['PHP_AUTH_USER'])) {
+        if (!isset($_SERVER['PHP_AUTH_USER']) || $_SERVER['PHP_AUTH_USER'] !== OpenPayU_Configuration::getMerchantPosId()) {
             $_SERVER['PHP_AUTH_USER'] = OpenPayU_Configuration::getMerchantPosId();
         }
-        if (!isset($_SERVER['PHP_AUTH_PW'])) {
+        if (!isset($_SERVER['PHP_AUTH_PW']) || $_SERVER['PHP_AUTH_PW'] !== OpenPayU_Configuration::getSignatureKey()) {
             $_SERVER['PHP_AUTH_PW'] = OpenPayU_Configuration::getSignatureKey();
         }
     }


### PR DESCRIPTION
Jeśli domena jest z certyfikatem SSL (https) to wtedy przy wywołaniu metody

```php
\OpenPayU_Order::consumeNotification($data);
```

Weryfikacja odbywa się przez

```php
verifyBasicAuthCredentials() 
```

które jeśli nie istniało to zwracało

```php
OpenPayU_Exception_Authorization
```

co nie miało sensu ponieważ

```php
$_SERVER['PHP_AUTH_USER']
```
musi być taki sam jak

```php
OpenPayU_Configuration::getMerchantPosId()
```