### PR TITLE
fix: Undefined property: stdClass::$statusDesc

### DIFF
--- a/lib/OpenPayU/Http.php
+++ b/lib/OpenPayU/Http.php
@@ -82,7 +82,7 @@ class OpenPayU_Http
     {
 
         $response = $message->getResponse();
-        $statusDesc = ($response->status && $response->status->statusDesc) ? $response->status->statusDesc : '';
+        $statusDesc = isset($response->status->statusDesc) ? $response->status->statusDesc : '';
 
         switch ($statusCode) {
             case 400:


### PR DESCRIPTION
API returned 'code' => 400, 'response' => '{"status":{"statusCode":"ERROR_SYNTAX","severity":"ERROR"}}' 

PHP in strict mode will throw "Undefined property" error. Tested on PHP v5.6.30
