### PR TITLE
Add a new exception type which holds the original server response

### DIFF
--- a/lib/OpenPayU/Http.php
+++ b/lib/OpenPayU/Http.php
@@ -73,6 +73,7 @@ class OpenPayU_Http
      * @param $statusCode
      * @param null $message
      * @throws OpenPayU_Exception
+     * @throws OpenPayU_Exception_Request
      * @throws OpenPayU_Exception_Authorization
      * @throws OpenPayU_Exception_Network
      * @throws OpenPayU_Exception_ServerMaintenance
@@ -86,7 +87,7 @@ class OpenPayU_Http
 
         switch ($statusCode) {
             case 400:
-                throw new OpenPayU_Exception($message->getStatus().' - '.$statusDesc, $statusCode);
+                throw new OpenPayU_Exception_Request($message, $message->getStatus().' - '.$statusDesc, $statusCode);
                 break;
 
             case 401:

--- a/lib/OpenPayU/OpenPayUException.php
+++ b/lib/OpenPayU/OpenPayUException.php
@@ -13,6 +13,25 @@ class OpenPayU_Exception extends \Exception
 
 }
 
+class OpenPayU_Exception_Request extends OpenPayU_Exception
+{
+    /** @var stdClass|null */
+    private $originalResponseMessage;
+
+    public function __construct($originalResponseMessage, $message = "", $code = 0, $previous = null)
+    {
+        $this->originalResponseMessage = $originalResponseMessage;
+
+        parent::__construct($message, $code, $previous);
+    }
+
+    /** @return null|stdClass */
+    public function getOriginalResponse()
+    {
+        return $this->originalResponseMessage;
+    }
+}
+
 class OpenPayU_Exception_Configuration extends OpenPayU_Exception
 {
 


### PR DESCRIPTION
#80 Store the initial response for further usage.

Benefits: The exception code can be send directly without parsing, all the message data is preserved for further usage by the consumers of the library.