### PR TITLE
Fix error when request don't have signature header

### DIFF
--- a/lib/OpenPayU/OpenPayU.php
+++ b/lib/OpenPayU/OpenPayU.php
@@ -33,6 +33,10 @@ class OpenPayU
     {
         $sign = OpenPayU_Util::parseSignature($incomingSignature);
 
+        if ($sign === null) {
+            throw new OpenPayU_Exception_Authorization('Signature not found');
+        }
+
         if (false === OpenPayU_Util::verifySignature(
                 $data,
                 $sign->signature,


### PR DESCRIPTION
This commit fixes error `Trying to get property of non-object` when incoming HTTP request doesn't have signature header - which results in `null` return from `parseSignature` code and PHP error. Correct behavior for this situation is exception. 